### PR TITLE
Allow For Overtime Play in "Game Over" Function

### DIFF
--- a/Baseball.py
+++ b/Baseball.py
@@ -37,12 +37,12 @@ def Game_Over():
             Game_Over = False
         if GSB['Bat_Team_Status']['Outs'] < 3 and GSB['Score'][Team[0]] > GSB['Score'][Team[1]]:
             Game_Over = False
-# tie game at bottom of ninth:               
-#       if GSB['Score'][Team[0]] == GSB['Score'][Team[1]]:
-#           Game_Over = False    
-# overtime option, continue until one team scores
-#   if GSB['Inning'] > 9 and GSB['Score'][Team[0]] == GSB['Score'][Team[1]]:
-#       Game_Over = False
+   # tie game at bottom of ninth:               
+        if GSB['Score'][Team[0]] == GSB['Score'][Team[1]]:
+            Game_Over = False    
+   # overtime option, continue until one team scores
+    if GSB['Inning'] > 9 and GSB['Score'][Team[0]] == GSB['Score'][Team[1]]:
+            Game_Over = False
     return Game_Over
 
 def Team_Up():
@@ -189,7 +189,6 @@ def Pitch():
         
 def Game():
     InitializeGSB()
-    # InitializeCount()
     Num_of_Plays = 0
     while not Game_Over():
         Num_of_Plays += 1


### PR DESCRIPTION
In the original commit, the game was ended at the bottom of the ninth, even if there was a tie score. Code in the "Game Over" function that handled overtime was commented out. This revision removes the comments in favor of the overtime code. Games will now end only when a team has scored and won, regardless of innings.